### PR TITLE
FIX support SSH CA user signed keys  in ssh_agent

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -428,6 +428,7 @@ Client.prototype.connect = function(cfg) {
   var hasSentAuth = false;
   function doNextAuth(authName) {
     hasSentAuth = true;
+    debug('------- DEBUG: doNextAuth authName : '+ authName);
     if (authName === false) {
       stream.removeListener('USERAUTH_FAILURE', onUSERAUTH_FAILURE);
       stream.removeListener('USERAUTH_PK_OK', onUSERAUTH_PK_OK);
@@ -547,6 +548,8 @@ Client.prototype.connect = function(cfg) {
       // Check that we support the key type first
       // TODO: move key type checking logic to ssh2-streams
       switch (pubKeyFullType) {
+        //TODO: there are a range of possible certs that are valid see https://github.com/PowerShell/openssh-portable/blob/8ab565c53f3619d6a1f5ac229e212cad8a52852c/sshkey.c#L138
+        case 'ssh-rsa-cert-v01@openssh.com':
         case 'ssh-rsa':
         case 'ssh-dss':
         case 'ecdsa-sha2-nistp256':
@@ -575,7 +578,11 @@ Client.prototype.connect = function(cfg) {
             var sigFullTypeLen = readUInt32BE(signed, 0);
             if (4 + sigFullTypeLen + 4 < signed.length) {
               var sigFullType = signed.toString('ascii', 4, 4 + sigFullTypeLen);
-              if (sigFullType !== pubKeyFullType) {
+              //TODO: construct a more robust all case cert error check see: https://github.com/PowerShell/openssh-portable/blob/8ab565c53f3619d6a1f5ac229e212cad8a52852c/auth2-pubkey.c#L89
+              if (!((pubKeyFullType === 'ssh-rsa-cert-v01@openssh.com' && sigFullType === 'ssh-rsa') ||
+              (sigFullType == pubKeyFullType))
+              )
+               {
                 err = new Error('Agent key/signature type mismatch');
                 err.level = 'agent';
                 self.emit('error', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "ssh2",
+  "version": "0.8.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "ssh2-streams": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
+      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,36 @@
-{ "name": "ssh2",
+{
+  "name": "ssh2",
   "version": "0.8.5",
   "author": "Brian White <mscdex@mscdex.net>",
   "description": "SSH2 client and server modules written in pure JavaScript for node.js",
   "main": "./lib/client",
-  "engines": { "node": ">=5.2.0" },
+  "engines": {
+    "node": ">=5.2.0"
+  },
   "dependencies": {
     "ssh2-streams": "~0.4.4"
   },
   "scripts": {
     "test": "node test/test.js"
   },
-  "keywords": [ "ssh", "ssh2", "sftp", "secure", "shell", "exec", "remote", "client" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/ssh2/raw/master/LICENSE" } ],
-  "repository" : { "type": "git", "url": "http://github.com/mscdex/ssh2.git" }
+  "keywords": [
+    "ssh",
+    "ssh2",
+    "sftp",
+    "secure",
+    "shell",
+    "exec",
+    "remote",
+    "client"
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/mscdex/ssh2/raw/master/LICENSE"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/mscdex/ssh2.git"
+  }
 }


### PR DESCRIPTION
PR https://github.com/mscdex/ssh2/pull/808 publickey support for SSH certificates is great but I found it was failing with when the keys and signed certificates where in ssh_agent

The changes I propose in this PR enable signed certs `ssh-rsa-cert-v01@openssh.com` to be correctly handled by the SSH client when retrieved from SSH_AGENT. This is the default  certificate type returned by Hashicorp Vault SSH CA signing. 

This PR does not handle the multitude of possible cert types and robustly handle the errors if this where the case. I don't like submitting something not fully complete but I am a Newbie to this wonderful world of PublicKey and Security so would hope someone with suitable experience would more confidently and robustly fill in the general cases. Thansk to @TimWolla for original work implementing Publickey Certificate support and hope @mscdex will review and merge soon